### PR TITLE
database parameter does not work

### DIFF
--- a/pandahouse/http.py
+++ b/pandahouse/http.py
@@ -18,7 +18,8 @@ def prepare(query, connection=None, external=None):
     connection = merge(_default, connection or {})
     database = escape(connection['database'])
     query = query.format(db=database)
-    params = {'query': query,
+    params = {'database': connection['database'],
+              'query': query,
               'user': connection['user'],
               'password': connection['password']}
     params = valfilter(lambda x: x, params)


### PR DESCRIPTION
sample code:
```python
ch = {'host': 'http://clickhouse:8123', 'database': 'telegraf', 'user': 'test', 'password': 'test'}

QUERY = "SELECT datetime, host, toStringCutToZero(path) AS path, total, free, used, used_percent FROM disk WHERE service = 'backup'"

df = read_clickhouse(QUERY, connection=ch)
```
give me error:

    pandahouse.http.ClickhouseException: Code: 60, e.displayText() = DB::Exception: Table default.disk doesn't exist., e.what() = DB::Exception