### PR TITLE
Allow reading of arrays - suggestion

### DIFF
--- a/pandahouse/convert.py
+++ b/pandahouse/convert.py
@@ -4,8 +4,7 @@ import numpy as np
 import pandas as pd
 from collections import OrderedDict
 from toolz import itemmap, keymap, valmap
-
-from .utils import decode_escapes
+from .utils import decode_escapes, decode_array
 
 
 MAPPING = {'object': 'String',
@@ -64,8 +63,11 @@ def to_dataframe(lines, **kwargs):
 
     dtypes, parse_dates, converters = {}, [], {}
     for name, chtype in zip(names, types):
-        dtype = CH2PD[chtype]
-        if dtype == 'object':
+        dtype = CH2PD.get(chtype, 'object')
+
+        if chtype.startswith("Array("):
+            converters[name] = decode_array
+        elif dtype == 'object':
             converters[name] = decode_escapes
         elif dtype.startswith('datetime'):
             parse_dates.append(name)

--- a/pandahouse/convert.py
+++ b/pandahouse/convert.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from collections import OrderedDict
 from toolz import itemmap, keymap, valmap
+
 from .utils import decode_escapes, decode_array
 
 

--- a/pandahouse/utils.py
+++ b/pandahouse/utils.py
@@ -1,6 +1,6 @@
 import re
-import codecs
 import json
+import codecs
 
 
 SPECIAL_CHARS = {

--- a/pandahouse/utils.py
+++ b/pandahouse/utils.py
@@ -1,5 +1,6 @@
 import re
 import codecs
+import json
 
 
 SPECIAL_CHARS = {
@@ -42,3 +43,13 @@ def _decode_match(match):
 
 def decode_escapes(s):
     return ESCAPE_SEQUENCE_RE.sub(_decode_match, s)
+
+
+def decode_array(clickhouse_array):
+    # Double quotes need escaping before parsed as JSON
+    clickhouse_array = clickhouse_array.replace('"', '\\"')
+    # Any non-escaped single quotes should be replaced with double quotes
+    clickhouse_array = re.sub("(?<!\\\\)'", '"', clickhouse_array)
+    # Finally any escaped single quotes can be replaced with unescaped ones
+    clickhouse_array = clickhouse_array.replace("\\'", "'")
+    return json.loads(clickhouse_array)


### PR DESCRIPTION
If this approach seems reasonable, I can clean it up and add testing.

What I've done is start by just telling pandas that array responses are objects, I couldn't see a better way of telling pandas what type of things to expect within the array.

Then, what clickhouse seems to have is basically JSON but with single and double quotes swapped around. By swapping them back (and escaping/unescaping the right things), and then using json.loads to read the response we get arrays back.

```
CREATE TABLE test_array
(
    str Array(String),
    dt Array(Date),
    int Array(UInt32),
    fl Array(Float64)
)
ENGINE = Memory
```

```
> insert into test_array values(['single \''], [CAST(now() as Date)], [1,2,3], [4.5,5.6])
```

Quick python testing locally
```
import pandahouse

df = pandahouse.read_clickhouse("select * from test_array")
print(df)

print(df["int"][0][0])
print(type(df["int"][0][0]))
```

Output
```
          str            dt        int          fl
0  [single ']  [2018-11-14]  [1, 2, 3]  [4.5, 5.6]
1
<class 'int'>
```

This is likely not very performant, but perhaps better than not being able to return anything at all. Another simpler option is to just mark any Array types as object and let the end user deal with the strings that come back.